### PR TITLE
Ignore declarations in @font-face rules

### DIFF
--- a/src/parser/declarations.js
+++ b/src/parser/declarations.js
@@ -1,7 +1,12 @@
 module.exports = tree => {
   const declarations = []
+  const IGNORE_FROM_PARENT = 'font-face'
 
   tree.walkDecls(declaration => {
+    if (declaration.parent.name === IGNORE_FROM_PARENT) {
+      return
+    }
+
     declarations.push({
       property: declaration.prop,
       value: declaration.value,

--- a/test/analyzer/declarations/input.css
+++ b/test/analyzer/declarations/input.css
@@ -69,9 +69,12 @@
 @keyframes empty {}
 
 /**
- * @font-face can have declarations too
+ * @font-faces don't have declarations, they have
+ * font descriptors, so these should be ignored
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#Descriptors
  */
 @font-face {
+  src: url('foo.com/font.woff');
   font-family: 'foo';
   font-weight: normal;
 }

--- a/test/analyzer/declarations/output.json
+++ b/test/analyzer/declarations/output.json
@@ -1,8 +1,8 @@
 {
-  "total": 24,
-  "totalUnique": 21,
+  "total": 22,
+  "totalUnique": 19,
   "importants": {
     "total": 3,
-    "share": 0.125
+    "share": 0.13636363636363635
   }
 }


### PR DESCRIPTION
Ignore declarations in @font-face rules, since they are technically descriptors instead. Fixes #31.

Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#Descriptors