### PR TITLE
Revert update of color-sorter to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "semicolon": false
   },
   "dependencies": {
-    "color-sorter": "^2.0.0",
+    "color-sorter": "2.0.0",
     "css-color-names": "^0.0.4",
     "css-shorthand-expand": "^1.2.0",
     "css-unit-sort": "^1.1.1",
     "path": "^0.12.7",
-    "postcss": "^7.0.1",
+    "postcss": "^7.0.2",
     "postcss-values-parser": "^1.5.0",
-    "specificity": "^0.4.0",
+    "specificity": "^0.4.1",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@ color-name@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
-color-sorter@^2.0.0:
+color-sorter@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/color-sorter/-/color-sorter-2.0.0.tgz#b802344624869234838e26b7baf8e13ae916b192"
   dependencies:
@@ -3666,9 +3666,9 @@ postcss-values-parser@^1.5.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.1.tgz#db20ca4fc90aa56809674eea75864148c66b67fa"
+postcss@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.2.tgz#7b5a109de356804e27f95a960bef0e4d5bc9bb18"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -4257,9 +4257,9 @@ spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
-specificity@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.0.tgz#301b1ab5455987c37d6d94f8c956ef9d9fb48c1d"
+specificity@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Color-sorter 2.1.0 is completely broken and [should be avoided](https://www.npmjs.com/package/color-sorter/v/2.1.0). This commit sets color sorter back from 2.1.0 to 2.0.0.