### PR TITLE
show the most common available duplicate as duplicate value

### DIFF
--- a/src/analyzer/values/colors.js
+++ b/src/analyzer/values/colors.js
@@ -64,7 +64,11 @@ const addShortestNotation = color => {
     ...color,
     value: [...color.aliases]
       .sort((a, b) => {
-        return a.value.length - b.value.length
+        if (a.count === b.count) {
+          return a.value.length - b.value.length
+        }
+
+        return b.count - a.count
       })
       .shift().value
   }

--- a/test/analyzer/values/output.json
+++ b/test/analyzer/values/output.json
@@ -365,7 +365,7 @@
       },
       {
         "count": 8,
-        "value": "#000",
+        "value": "black",
         "aliases": [
           {
             "value": "hsl(0,0,0)",


### PR DESCRIPTION
Instead of showing the shortest notation possible of any duplicate color, show the one that's the most common as the duplicate value. It makes more sense to show `#fff` as a duplicate if it appears 100 times as opposed to showing `white` that only appears once.