### PR TITLE
use default reporting for color duplicates

### DIFF
--- a/src/analyzer/values/colors.js
+++ b/src/analyzer/values/colors.js
@@ -144,11 +144,16 @@ module.exports = declarations => {
       return [...allColors, ...declarationColors]
     }, [])
   const {totalUnique, unique} = uniquer(all, colorSorter.sortFn)
+  const duplicates = withDuplicateNotations(unique)
 
   return {
     total: all.length,
     unique,
     totalUnique,
-    duplicates: withDuplicateNotations(unique)
+    duplicates: {
+      unique: duplicates,
+      totalUnique: duplicates.length,
+      total: duplicates.length
+    }
   }
 }

--- a/test/analyzer/index.js
+++ b/test/analyzer/index.js
@@ -171,7 +171,11 @@ test('Returns the correct analysis object structure', async t => {
         total: 0,
         totalUnique: 0,
         unique: [],
-        duplicates: []
+        duplicates: {
+          total: 0,
+          totalUnique: 0,
+          unique: []
+        }
       },
       fontfamilies: {
         total: 0,

--- a/test/analyzer/values/output.json
+++ b/test/analyzer/values/output.json
@@ -272,132 +272,136 @@
         "count": 1
       }
     ],
-    "duplicates": [
-      {
-        "count": 2,
-        "value": "rgba(0,0,0,0)",
-        "notations": [
-          {
-            "value": "hsla(0,0%,0%,0)",
-            "count": 1
-          },
-          {
-            "value": "rgba(0,0,0,0)",
-            "count": 1
-          }
-        ]
-      },
-      {
-        "value": "rgba(100, 200, 10, .5)",
-        "count": 2,
-        "notations": [
-          {
-            "count": 1,
-            "value": "rgba(100, 200, 10, .5)"
-          },
-          {
-            "count": 1,
-            "value": "rgba(100, 200, 10, 0.5)"
-          }
-        ]
-      },
-      {
-        "value": "hsl(270,60%,70%)",
-        "count": 3,
-        "notations": [
-          {
-            "count": 1,
-            "value": "hsl(270,60%,70%)"
-          },
-          {
-            "count": 1,
-            "value": "hsl(270, 60%, 70%)"
-          },
-          {
-            "count": 1,
-            "value": "hsl(270 60% 70%)"
-          }
-        ]
-      },
-      {
-        "value": "hsl(270 60% 50% / .15)",
-        "count": 4,
-        "notations": [
-          {
-            "count": 1,
-            "value": "hsl(270, 60%, 50%, 15%)"
-          },
-          {
-            "count": 1,
-            "value": "hsl(270 60% 50% / .15)"
-          },
-          {
-            "count": 1,
-            "value": "hsl(270 60% 50% / 15%)"
-          },
-          {
-            "count": 1,
-            "value": "hsl(270, 60%, 50%, .15)"
-          }
-        ]
-      },
-      {
-        "value": "#fff",
-        "count": 4,
-        "notations": [
-          {
-            "count": 1,
-            "value": "hsl(360, 100%, 100%)"
-          },
-          {
-            "count": 1,
-            "value": "white"
-          },
-          {
-            "count": 1,
-            "value": "#fff"
-          },
-          {
-            "count": 1,
-            "value": "rgb(255, 255, 255)"
-          }
-        ]
-      },
-      {
-        "count": 8,
-        "value": "black",
-        "notations": [
-          {
-            "value": "hsl(0,0,0)",
-            "count": 1
-          },
-          {
-            "value": "rgba(0,0,0,1)",
-            "count": 1
-          },
-          {
-            "value": "hsla(0,0,0,1)",
-            "count": 1
-          },
-          {
-            "value": "#000000",
-            "count": 1
-          },
-          {
-            "value": "black",
-            "count": 2
-          },
-          {
-            "value": "#000",
-            "count": 1
-          },
-          {
-            "value": "rgb(0,0,0)",
-            "count": 1
-          }
-        ]
-      }
-    ]
+    "duplicates": {
+      "total": 6,
+      "totalUnique": 6,
+      "unique": [
+        {
+          "count": 2,
+          "value": "rgba(0,0,0,0)",
+          "notations": [
+            {
+              "value": "hsla(0,0%,0%,0)",
+              "count": 1
+            },
+            {
+              "value": "rgba(0,0,0,0)",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "value": "rgba(100, 200, 10, .5)",
+          "count": 2,
+          "notations": [
+            {
+              "count": 1,
+              "value": "rgba(100, 200, 10, .5)"
+            },
+            {
+              "count": 1,
+              "value": "rgba(100, 200, 10, 0.5)"
+            }
+          ]
+        },
+        {
+          "value": "hsl(270,60%,70%)",
+          "count": 3,
+          "notations": [
+            {
+              "count": 1,
+              "value": "hsl(270,60%,70%)"
+            },
+            {
+              "count": 1,
+              "value": "hsl(270, 60%, 70%)"
+            },
+            {
+              "count": 1,
+              "value": "hsl(270 60% 70%)"
+            }
+          ]
+        },
+        {
+          "value": "hsl(270 60% 50% / .15)",
+          "count": 4,
+          "notations": [
+            {
+              "count": 1,
+              "value": "hsl(270, 60%, 50%, 15%)"
+            },
+            {
+              "count": 1,
+              "value": "hsl(270 60% 50% / .15)"
+            },
+            {
+              "count": 1,
+              "value": "hsl(270 60% 50% / 15%)"
+            },
+            {
+              "count": 1,
+              "value": "hsl(270, 60%, 50%, .15)"
+            }
+          ]
+        },
+        {
+          "value": "#fff",
+          "count": 4,
+          "notations": [
+            {
+              "count": 1,
+              "value": "hsl(360, 100%, 100%)"
+            },
+            {
+              "count": 1,
+              "value": "white"
+            },
+            {
+              "count": 1,
+              "value": "#fff"
+            },
+            {
+              "count": 1,
+              "value": "rgb(255, 255, 255)"
+            }
+          ]
+        },
+        {
+          "count": 8,
+          "value": "black",
+          "notations": [
+            {
+              "value": "hsl(0,0,0)",
+              "count": 1
+            },
+            {
+              "value": "rgba(0,0,0,1)",
+              "count": 1
+            },
+            {
+              "value": "hsla(0,0,0,1)",
+              "count": 1
+            },
+            {
+              "value": "#000000",
+              "count": 1
+            },
+            {
+              "value": "black",
+              "count": 2
+            },
+            {
+              "value": "#000",
+              "count": 1
+            },
+            {
+              "value": "rgb(0,0,0)",
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
   },
   "browserhacks": {
     "total": 1,


### PR DESCRIPTION
the reporting for color duplicates was different from all other reporting and it didn't tell us how many duplicates there were for example. This commit fixes just that.

closes #61