### PR TITLE
flatten output by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2883,6 +2883,21 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "requires": {
+        "is-buffer": "~2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "css-shorthand-expand": "^1.2.0",
     "css-unit-sort": "^1.1.1",
     "css-value-browser-h4cks-analyzer": "^1.0.1",
+    "flat": "^4.1.0",
     "is-vendor-prefixed": "^1.0.0",
     "path": "^0.12.7",
     "postcss": "^7.0.2",

--- a/src/analyzer/index.js
+++ b/src/analyzer/index.js
@@ -1,27 +1,37 @@
+const flat = require('flat')
 const parser = require('../parser')
 
-module.exports = input => {
+function flattenObject(obj) {
+  return flat(obj, {safe: true})
+}
+
+module.exports = rawCss => {
   return new Promise(async (resolve, reject) => {
-    try {
-      const css = await parser(input)
+    const css = await parser(rawCss).catch(error => reject(error))
 
-      const atrules = require('./atrules')(css.atRules)
-      const rules = require('./rules')(css.rules)
-      const selectors = require('./selectors')(css.selectors)
-      const declarations = require('./declarations')(css.declarations)
-      const properties = require('./properties')(css.declarations)
-      const values = require('./values')(css.declarations)
-      const stylesheets = require('./stylesheets')(
-        input,
-        atrules,
-        rules,
-        selectors,
-        declarations,
-        properties,
-        values
-      )
+    // CSS undefined means that PostCSS encountered an error
+    if (typeof css === 'undefined') {
+      return reject(new Error('Invalid CSS found, cannot analyze invalid CSS'))
+    }
 
-      resolve({
+    const atrules = require('./atrules')(css.atRules)
+    const rules = require('./rules')(css.rules)
+    const selectors = require('./selectors')(css.selectors)
+    const declarations = require('./declarations')(css.declarations)
+    const properties = require('./properties')(css.declarations)
+    const values = require('./values')(css.declarations)
+    const stylesheets = require('./stylesheets')({
+      rawCss,
+      atrules,
+      rules,
+      selectors,
+      declarations,
+      properties,
+      values
+    })
+
+    return resolve(
+      flattenObject({
         stylesheets,
         atrules,
         rules,
@@ -30,8 +40,6 @@ module.exports = input => {
         properties,
         values
       })
-    } catch (error) {
-      reject(error)
-    }
+    )
   })
 }

--- a/src/analyzer/stylesheets/index.js
+++ b/src/analyzer/stylesheets/index.js
@@ -1,13 +1,13 @@
-module.exports = (
-  raw,
+module.exports = ({
+  rawCss,
   atrules,
   rules,
   selectors,
   declarations,
   properties,
   values
-) => {
-  const size = Buffer.byteLength(raw, 'utf8')
+}) => {
+  const size = Buffer.byteLength(rawCss, 'utf8')
   const simplicity = require('./simplicity.js')(rules, selectors)
   const cohesion = require('./cohesion.js')(rules, declarations)
   const browserhacks = require('./browserhacks.js')(

--- a/test/analyzer/index.js
+++ b/test/analyzer/index.js
@@ -12,189 +12,102 @@ test('Passes with valid CSS', async t => {
 test('Returns the correct analysis object structure', async t => {
   const actual = await analyzer('foo{}')
   const expected = {
-    atrules: {
-      charsets: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      documents: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      fontfaces: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      imports: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      keyframes: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      mediaqueries: {
-        total: 0,
-        totalUnique: 0,
-        unique: [],
-        browserhacks: {
-          total: 0,
-          unique: [],
-          totalUnique: 0
-        }
-      },
-      namespaces: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      pages: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      supports: {
-        total: 0,
-        totalUnique: 0,
-        unique: [],
-        browserhacks: {
-          total: 0,
-          unique: [],
-          totalUnique: 0
-        }
-      }
-    },
-    declarations: {
-      importants: {
-        share: 0,
-        total: 0
-      },
-      total: 0,
-      totalUnique: 0
-    },
-    properties: {
-      prefixed: {
-        share: 0,
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      browserhacks: {
-        total: 0,
-        unique: [],
-        totalUnique: 0
-      },
-      total: 0,
-      totalUnique: 0,
-      unique: []
-    },
-    rules: {
-      total: 1,
-      empty: {
-        total: 1
-      }
-    },
-    selectors: {
-      accessibility: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      id: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      identifiers: {
-        average: 1,
-        top: [
-          {
-            identifiers: 1,
-            selector: 'foo'
-          }
-        ]
-      },
-      js: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      specificity: {
-        top: [
-          {
-            selector: 'foo',
-            specificity: {
-              a: 0,
-              b: 0,
-              c: 0,
-              d: 1
-            }
-          }
-        ]
-      },
-      total: 1,
-      totalUnique: 1,
-      universal: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      browserhacks: {
-        total: 0,
-        unique: [],
-        totalUnique: 0
-      }
-    },
-    stylesheets: {
-      cohesion: {
-        average: 0
-      },
-      simplicity: 1,
-      size: 5,
-      browserhacks: {
-        total: 0,
-        totalUnique: 0
-      }
-    },
-    values: {
-      browserhacks: {
-        total: 0,
-        unique: [],
-        totalUnique: 0
-      },
-      colors: {
-        total: 0,
-        totalUnique: 0,
-        unique: [],
-        duplicates: {
-          total: 0,
-          totalUnique: 0,
-          unique: []
-        }
-      },
-      fontfamilies: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      fontsizes: {
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      prefixed: {
-        share: 0,
-        total: 0,
-        totalUnique: 0,
-        unique: []
-      },
-      total: 0
-    }
+    'atrules.charsets.total': 0,
+    'atrules.charsets.totalUnique': 0,
+    'atrules.charsets.unique': [],
+    'atrules.documents.total': 0,
+    'atrules.documents.totalUnique': 0,
+    'atrules.documents.unique': [],
+    'atrules.fontfaces.total': 0,
+    'atrules.fontfaces.totalUnique': 0,
+    'atrules.fontfaces.unique': [],
+    'atrules.imports.total': 0,
+    'atrules.imports.totalUnique': 0,
+    'atrules.imports.unique': [],
+    'atrules.keyframes.total': 0,
+    'atrules.keyframes.totalUnique': 0,
+    'atrules.keyframes.unique': [],
+    'atrules.mediaqueries.total': 0,
+    'atrules.mediaqueries.totalUnique': 0,
+    'atrules.mediaqueries.unique': [],
+    'atrules.mediaqueries.browserhacks.total': 0,
+    'atrules.mediaqueries.browserhacks.unique': [],
+    'atrules.mediaqueries.browserhacks.totalUnique': 0,
+    'atrules.namespaces.total': 0,
+    'atrules.namespaces.totalUnique': 0,
+    'atrules.namespaces.unique': [],
+    'atrules.pages.total': 0,
+    'atrules.pages.totalUnique': 0,
+    'atrules.pages.unique': [],
+    'atrules.supports.total': 0,
+    'atrules.supports.totalUnique': 0,
+    'atrules.supports.unique': [],
+    'atrules.supports.browserhacks.total': 0,
+    'atrules.supports.browserhacks.unique': [],
+    'atrules.supports.browserhacks.totalUnique': 0,
+    'declarations.importants.share': 0,
+    'declarations.importants.total': 0,
+    'declarations.total': 0,
+    'declarations.totalUnique': 0,
+    'properties.prefixed.share': 0,
+    'properties.prefixed.total': 0,
+    'properties.prefixed.totalUnique': 0,
+    'properties.prefixed.unique': [],
+    'properties.browserhacks.total': 0,
+    'properties.browserhacks.unique': [],
+    'properties.browserhacks.totalUnique': 0,
+    'properties.total': 0,
+    'properties.totalUnique': 0,
+    'properties.unique': [],
+    'rules.total': 1,
+    'rules.empty.total': 1,
+    'selectors.accessibility.total': 0,
+    'selectors.accessibility.totalUnique': 0,
+    'selectors.accessibility.unique': [],
+    'selectors.id.total': 0,
+    'selectors.id.totalUnique': 0,
+    'selectors.id.unique': [],
+    'selectors.identifiers.average': 1,
+    'selectors.identifiers.top': [{identifiers: 1, selector: 'foo'}],
+    'selectors.js.total': 0,
+    'selectors.js.totalUnique': 0,
+    'selectors.js.unique': [],
+    'selectors.specificity.top': [
+      {selector: 'foo', specificity: {a: 0, b: 0, c: 0, d: 1}}
+    ],
+    'selectors.total': 1,
+    'selectors.totalUnique': 1,
+    'selectors.universal.total': 0,
+    'selectors.universal.totalUnique': 0,
+    'selectors.universal.unique': [],
+    'selectors.browserhacks.total': 0,
+    'selectors.browserhacks.unique': [],
+    'selectors.browserhacks.totalUnique': 0,
+    'stylesheets.cohesion.average': 0,
+    'stylesheets.simplicity': 1,
+    'stylesheets.size': 5,
+    'stylesheets.browserhacks.total': 0,
+    'stylesheets.browserhacks.totalUnique': 0,
+    'values.browserhacks.total': 0,
+    'values.browserhacks.unique': [],
+    'values.browserhacks.totalUnique': 0,
+    'values.colors.total': 0,
+    'values.colors.totalUnique': 0,
+    'values.colors.unique': [],
+    'values.colors.duplicates.total': 0,
+    'values.colors.duplicates.totalUnique': 0,
+    'values.colors.duplicates.unique': [],
+    'values.fontfamilies.total': 0,
+    'values.fontfamilies.totalUnique': 0,
+    'values.fontfamilies.unique': [],
+    'values.fontsizes.total': 0,
+    'values.fontsizes.totalUnique': 0,
+    'values.fontsizes.unique': [],
+    'values.prefixed.share': 0,
+    'values.prefixed.total': 0,
+    'values.prefixed.totalUnique': 0,
+    'values.prefixed.unique': [],
+    'values.total': 0
   }
 
   t.deepEqual(actual, expected)

--- a/test/utils/scope-tester.js
+++ b/test/utils/scope-tester.js
@@ -1,6 +1,11 @@
 const path = require('path')
 const fs = require('fs')
+const flat = require('flat')
 const analyzer = require('../..')
+
+function unFlattenObject(obj) {
+  return flat.unflatten(obj, {safe: true})
+}
 
 function readFile(file) {
   let src = fs.readFileSync(file, 'utf8')
@@ -23,7 +28,7 @@ module.exports = async scope => {
   const expected = JSON.parse(readFile(outputFile))
 
   return {
-    actual,
+    actual: unFlattenObject(actual),
     expected
   }
 }


### PR DESCRIPTION
Most tools that consume the output from this module convert the output to a flat object, so we might as well do it here.

Some thoughts:

* Files in the test directory unflatten the results so I don't have to re-write the whole test suite for now (see https://github.com/projectwallace/css-analyzer/issues/81)
* There is (IMHO) better error handling for invalid css now

closes #50