### PR TITLE
filter empty selector

### DIFF
--- a/src/parser/selectors.js
+++ b/src/parser/selectors.js
@@ -17,7 +17,7 @@ module.exports = tree => {
 }
 
 const getSelectorsFromRule = rule => {
-  return rule.selector.split(',').map(s => s.trim())
+  return rule.selector.split(',').map(s => s.trim()).filter(selector => selector)
 }
 
 module.exports.getSelectorsFromRule = getSelectorsFromRule

--- a/test/parser/selectors.js
+++ b/test/parser/selectors.js
@@ -14,6 +14,32 @@ test('basic selectors are parsed', async t => {
   t.deepEqual(actual, expected)
 })
 
+test('basic selectors example 2 are parsed', async t => {
+  const fixture = `
+    .a,
+    {}
+  `
+  const {selectors: actual} = await parser(fixture)
+  const expected = ['.a']
+
+  t.deepEqual(actual, expected)
+})
+
+test('basic selectors example 3 are parsed', async t => {
+  const fixture = `
+    .a,
+    .b,
+    .c,
+    .d,
+    .e,
+    {}
+  `
+  const {selectors: actual} = await parser(fixture)
+  const expected = ['.a', '.b', '.c', '.d', '.e']
+
+  t.deepEqual(actual, expected)
+})
+
 test('"selectors" in @keyframes are not passed as actual selectors', async t => {
   const fixture = `
     @keyframes no-selector {


### PR DESCRIPTION
bug fix 


fix before:
```
$ cat 1.css
.a,
{
    margin: 10px;
}

$ cat 1.css | wallace
TypeError: Cannot read property 'specificityArray' of undefined
```

```
$ cat 2.css
.a,
.b,
.c,
.d,
.e,
{
    margin: 10px;
}

$ cat 2.css | wallace
TypeError: Cannot read property 'selector' of undefined
```

after:
```
$ cat 1.css
.a,
{
    margin: 10px;
}

$ cat 1.css | wallace

Complexity
----------------------------------------------------
                          Total   Average    Maximum
‣ Lines of Code               2
‣ Rules                       1
‣ Selectors                   1      1.00          1
‣ Identifiers                 1      1.00          1
‣ Declarations                1      1.00          1

                          Total    Unique   Unique %
‣ Browser hacks               0         0       0.0%
‣ @supports                   0         0       0.0%
‣ @media                      0         0       0.0%
‣ Z-indexes                   0         0       0.0%

....etc
```


```
$ cat 2.css
.a,
.b,
.c,
.d,
.e,
{
    margin: 10px;
}

$ cat 2.css | wallace

Complexity
----------------------------------------------------
                          Total   Average    Maximum
‣ Lines of Code               6
‣ Rules                       1
‣ Selectors                   5      5.00          5
‣ Identifiers                 5      1.00          1
‣ Declarations                1      1.00          1

                          Total    Unique   Unique %
‣ Browser hacks               0         0       0.0%
‣ @supports                   0         0       0.0%
‣ @media                      0         0       0.0%
‣ Z-indexes                   0         0       0.0%

.....etc
```
