### PR TITLE
Don't throw on trailing commas in SelectorList

### DIFF
--- a/src/parser/selectors.js
+++ b/src/parser/selectors.js
@@ -17,7 +17,10 @@ module.exports = tree => {
 }
 
 const getSelectorsFromRule = rule => {
-  return rule.selector.split(',').map(s => s.trim())
+  return rule.selector
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
 }
 
 module.exports.getSelectorsFromRule = getSelectorsFromRule

--- a/test/parser/selectors.js
+++ b/test/parser/selectors.js
@@ -32,3 +32,17 @@ test('"selectors" in @keyframes are not passed as actual selectors', async t => 
 
   t.deepEqual(actual, expected)
 })
+
+test('it ignores trailing commas in selectorLists', async t => {
+  const fixture = `
+    html,
+    body, {
+      color: red;
+    }
+  `
+
+  const {selectors: actual} = await parser(fixture)
+  const expected = ['html', 'body']
+
+  t.deepEqual(actual, expected)
+})


### PR DESCRIPTION
Closes #157 (thnx again @xqin for reporting!)

Technically a traling comma in a SelectorList is a syntax error that the CSS
engine does not know how to handle
(reduced testcase: https://codepen.io/bartveneman/pen/NWWYJOE).
But this analyzer tries to give insight in your CSS complexity, not in the
validity of it. There are better tools for that. So for that, it'll look
the other way and continue analyzing.