### PR TITLE
Reduce bundle size: 169kB -> 76kB

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "uvu",
     "test:watch": "watchlist src -- npm test",
-    "build": "microbundle --external=none",
+    "build": "microbundle --external=none --raw",
     "dev": "microbundle watch"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "uvu",
     "test:watch": "watchlist src -- npm test",
-    "build": "microbundle",
+    "build": "microbundle --external=none",
     "dev": "microbundle watch"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "uvu",
     "test:watch": "watchlist src -- npm test",
-    "build": "microbundle --external=none --raw",
+    "build": "microbundle",
     "dev": "microbundle watch"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import parse from 'css-tree/parser'
 import walk from 'css-tree/walker'
-// import { property as cssProperty } from 'css-tree'
+import { property as getProperty } from '../node_modules/css-tree/lib/utils/names.js'
 import { compareSpecificity } from './selectors/specificity.js'
 import { analyzeRules } from './rules/rules.js'
 import { colorFunctions, colorNames } from './values/colors.js'
@@ -143,16 +143,9 @@ const analyze = (css) => {
           })
 
           const { value, property } = node
-          const fullProperty = {
-            authored: property,
-            // ...cssProperty(property)
-            basename: property,
-            name: property,
-            hack: false,
-            vendor: '',
-            prefix: '',
-            custom: false,
-          }
+          const fullProperty = Object.assign({
+            authored: property
+          }, getProperty(property))
 
           properties.push(fullProperty)
           values.push(value)
@@ -200,7 +193,7 @@ const analyze = (css) => {
             }
           }
 
-          walk(node.value, {
+          walk(value, {
             enter: function (valueNode) {
               switch (valueNode.type) {
                 case 'Hash': {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-import * as csstree from 'css-tree'
+import parse from 'css-tree/parser'
+import walk from 'css-tree/walker'
+import { property as cssProperty } from 'css-tree'
 import { compareSpecificity } from './selectors/specificity.js'
 import { analyzeRules } from './rules/rules.js'
 import { colorFunctions, colorNames } from './values/colors.js'
@@ -66,7 +68,7 @@ const analyze = (css) => {
   let totalComments = 0
   let commentsSize = 0
 
-  const ast = csstree.parse(css, {
+  const ast = parse(css, {
     parseAtrulePrelude: false,
     parseCustomProperty: true, // To find font-families, colors, etc.
     positions: true, // So we can use stringifyNode()
@@ -96,7 +98,7 @@ const analyze = (css) => {
   const units = new ContextCollection()
   const embeds = new CountableCollection()
 
-  csstree.walk(ast, {
+  walk(ast, {
     enter: function (node) {
       switch (node.type) {
         case 'Atrule': {
@@ -143,7 +145,7 @@ const analyze = (css) => {
           const { value, property } = node
           const fullProperty = {
             authored: property,
-            ...csstree.property(property)
+            ...cssProperty(property)
           }
 
           properties.push(fullProperty)
@@ -192,7 +194,7 @@ const analyze = (css) => {
             }
           }
 
-          csstree.walk(node.value, {
+          walk(node.value, {
             enter: function (valueNode) {
               switch (valueNode.type) {
                 case 'Hash': {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import parse from 'css-tree/parser'
 import walk from 'css-tree/walker'
-import { property as cssProperty } from 'css-tree'
+// import { property as cssProperty } from 'css-tree'
 import { compareSpecificity } from './selectors/specificity.js'
 import { analyzeRules } from './rules/rules.js'
 import { colorFunctions, colorNames } from './values/colors.js'
@@ -145,7 +145,13 @@ const analyze = (css) => {
           const { value, property } = node
           const fullProperty = {
             authored: property,
-            ...cssProperty(property)
+            // ...cssProperty(property)
+            basename: property,
+            name: property,
+            hack: false,
+            vendor: '',
+            prefix: '',
+            custom: false,
           }
 
           properties.push(fullProperty)

--- a/src/rules/rules.js
+++ b/src/rules/rules.js
@@ -1,4 +1,4 @@
-import * as csstree from 'css-tree'
+import walk from 'css-tree/walker'
 import { AggregateCollection } from '../aggregate-collection.js'
 
 const analyzeRules = ({ rules }) => {
@@ -13,7 +13,7 @@ const analyzeRules = ({ rules }) => {
     let selectors = 0
     let declarations = 0
 
-    csstree.walk(rules[i], {
+    walk(rules[i], {
       enter: function (childNode) {
         if (childNode.type === 'Selector') {
           selectors++

--- a/src/values/font-families.js
+++ b/src/values/font-families.js
@@ -1,4 +1,5 @@
-import * as csstree from 'css-tree'
+import walk from 'css-tree/walker'
+import generate from 'css-tree/generator'
 import { CountableCollection } from '../countable-collection.js'
 
 const systemKeywords = {
@@ -69,7 +70,7 @@ const analyzeFontFamilies = ({ fontValues, fontFamilyValues }) => {
 
     const parts = []
 
-    csstree.walk(value, {
+    walk(value, {
       reverse: true,
       enter: function (fontNode) {
         if (fontNode.type === 'String') {
@@ -87,7 +88,7 @@ const analyzeFontFamilies = ({ fontValues, fontFamilyValues }) => {
       }
     })
 
-    all.push(parts.map(csstree.generate).join(''))
+    all.push(parts.map(generate).join(''))
   }
 
   return all.count()

--- a/src/values/font-sizes.js
+++ b/src/values/font-sizes.js
@@ -1,4 +1,4 @@
-import * as csstree from 'css-tree'
+import walk from 'css-tree/walker'
 import { CountableCollection } from '../countable-collection.js'
 
 const sizeKeywords = {
@@ -47,7 +47,7 @@ const analyzeFontSizes = ({ stringifyNode, fontSizeValues, fontValues }) => {
     let operator = false
     let size
 
-    csstree.walk(fontNode, {
+    walk(fontNode, {
       enter: function (fontNode) {
         switch (fontNode.type) {
           case 'Number': {


### PR DESCRIPTION
Before

```
$ npm run build

> @projectwallace/css-analyzer@5.1.0 build
> microbundle --external=none

Build "@projectwallace/css-analyzer" to dist:
      49.1 kB: analyzer.cjs.gz
      43.2 kB: analyzer.cjs.br
        49 kB: analyzer.modern.js.gz
      42.9 kB: analyzer.modern.js.br
      49.1 kB: analyzer.module.js.gz
      43.2 kB: analyzer.module.js.br
      49.3 kB: analyzer.umd.js.gz
      43.4 kB: analyzer.umd.js.br

$ ls -alh dist

169K analyzer.cjs
617K analyzer.cjs.map
168K analyzer.modern.js
617K analyzer.modern.js.map
169K analyzer.module.js
617K analyzer.module.js.map
169K analyzer.umd.js
618K analyzer.umd.js.map
```

After

```
$ npm run build

> @projectwallace/css-analyzer@5.1.0 build
> microbundle --external=none

Build "@projectwallace/css-analyzer" to dist:
      22.5 kB: analyzer.cjs.gz
      20.2 kB: analyzer.cjs.br
      22.3 kB: analyzer.modern.js.gz
        20 kB: analyzer.modern.js.br
      22.5 kB: analyzer.module.js.gz
      20.2 kB: analyzer.module.js.br
      22.7 kB: analyzer.umd.js.gz
      20.4 kB: analyzer.umd.js.br

$ ls -alh dist

 76K analyzer.cjs
362K analyzer.cjs.map
 76K analyzer.modern.js
363K analyzer.modern.js.map
 76K analyzer.module.js
362K analyzer.module.js.map
 76K analyzer.umd.js
363K analyzer.umd.js.map
7.3K index.d.ts
```

## Todo

- [x] [Importing of utils from csstree doesn't seem to work](https://github.com/csstree/csstree/issues/181): `import { getPropertyDescriptor } from 'csstree/utils`
