### PR TITLE
reduce memory usage for OccurrenceCounter by hashing the values

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -2,16 +2,16 @@ import byteSize from './format-filesize.js'
 import { analyze as analyzeCss } from '../dist/analyzer.modern.js'
 import * as fs from 'fs'
 const files = [
-  ['bol-com-20190617', 'Bol.com', 115],
-  ['bootstrap-5.0.0', 'Bootstrap 5.0.0', 47],
-  ['cnn-20220403', 'CNN', 360],
-  ['css-tricks-20190319', 'CSS-Tricks', 51],
-  ['facebook-20190319', 'Facebook.com', 69],
-  ['github-20210501', 'GitHub.com', 91],
-  ['gazelle-20210905', 'Gazelle.nl', 300],
-  ['lego-20190617', 'Lego.com', 53],
-  ['smashing-magazine-20190319', 'Smashing Magazine.com', 285],
-  ['trello-20190617', 'Trello.com', 80],
+  ['bol-com-20190617', 'Bol.com', 137],
+  ['bootstrap-5.0.0', 'Bootstrap 5.0.0', 55],
+  ['cnn-20220403', 'CNN', 419],
+  ['css-tricks-20190319', 'CSS-Tricks', 58],
+  ['facebook-20190319', 'Facebook.com', 84],
+  ['github-20210501', 'GitHub.com', 105],
+  ['gazelle-20210905', 'Gazelle.nl', 336],
+  ['lego-20190617', 'Lego.com', 64],
+  ['smashing-magazine-20190319', 'Smashing Magazine.com', 329],
+  ['trello-20190617', 'Trello.com', 94],
 ]
 
 let maxLen = -1

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import { OccurrenceCounter } from './occurrence-counter.js'
  * @param {string} css
  */
 const analyze = (css) => {
-  const start = new Date()
+  const start = Date.now()
 
   // We need all lines later on when we need to stringify the AST again
   // e.g. for Selectors
@@ -68,7 +68,7 @@ const analyze = (css) => {
   let commentsSize = 0
   const embeds = new CountableCollection()
 
-  const startParse = new Date()
+  const startParse = Date.now()
 
   const ast = parse(css, {
     parseAtrulePrelude: false,
@@ -80,7 +80,7 @@ const analyze = (css) => {
     },
   })
 
-  const startAnalysis = new Date()
+  const startAnalysis = Date.now()
 
   // Atrules
   let totalAtRules = 0
@@ -576,8 +576,8 @@ const analyze = (css) => {
     },
     __meta__: {
       parseTime: startAnalysis - startParse,
-      analyzeTime: new Date() - startAnalysis,
-      total: new Date() - start
+      analyzeTime: Date.now() - startAnalysis,
+      total: Date.now() - start
     }
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,24 +1,6 @@
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { analyze, compareSpecificity } from './index.js'
-import { readFileSync } from 'fs'
-
-const fixtures = [
-  'bol-com-20190617.css',
-  'css-tricks-20190319.css',
-  'facebook-20190319.css',
-  'gazelle-20210905.css',
-  'github-20210501.css',
-  'lego-20190617.css',
-  'smashing-magazine-20190319.css',
-  'trello-20190617.css',
-].map(fileName => {
-  const css = readFileSync(`./src/__fixtures__/${fileName}`, 'utf-8')
-  return {
-    css,
-    fileName
-  }
-})
 
 const Api = suite('Public API')
 
@@ -339,6 +321,36 @@ Api('handles empty input gracefully', () => {
   }
 
   assert.equal(actual, expected)
+})
+
+Api('has metadata', () => {
+  const fixture = Array.from({ length: 10 }).map(_ => `
+    html {
+      font: 1em/1 sans-serif;
+      color: rgb(0 0 0 / 0.5);
+    }
+
+    @media screen {
+      @supports (display: grid) {
+        test::after :where(test) :is(done) {
+          display: grid;
+          color: #f00;
+        }
+      }
+    }
+  `).join('')
+
+  const result = analyze(fixture)
+  const actual = result.__meta__
+
+  assert.type(actual.parseTime, 'number')
+  assert.ok(actual.parseTime > 0, `expected parseTime to be bigger than 0, got ${actual.parseTime}`)
+
+  assert.type(actual.analyzeTime, 'number')
+  assert.ok(actual.analyzeTime > 0, `expected analyzeTime to be bigger than 0, got ${actual.parseTime}`)
+
+  assert.type(actual.total, 'number')
+  assert.ok(actual.total > 0, `expected total time to be bigger than 0, got ${actual.parseTime}`)
 })
 
 Api.run()

--- a/src/occurrence-counter.js
+++ b/src/occurrence-counter.js
@@ -1,3 +1,9 @@
+/**
+ * Convert a string to a number
+ * @param {string} str
+ * @returns {number} the hashed string
+ * @see https://stackoverflow.com/a/51276700
+ */
 function hash(str) {
   let hash = 0x811c9dc5
   var prime = 0x000193
@@ -15,6 +21,14 @@ export class OccurrenceCounter {
     this._items = Object.create(null)
   }
 
+  /**
+   * Converting the CSS string to an integer because this collection potentially
+   * becomes very large and storing the values as integers saves 10-70%
+   *
+   * @see https://github.com/projectwallace/css-analyzer/pull/242
+   * @param {string} item
+   * @returns {number} the count for this item
+   */
   push(item) {
     const key = hash(item)
 

--- a/src/occurrence-counter.js
+++ b/src/occurrence-counter.js
@@ -1,14 +1,28 @@
+function hash(str) {
+  let hash = 0x811c9dc5
+  var prime = 0x000193
+
+  for (let i = 0; i < str.length; i++) {
+    hash = hash ^ str.charCodeAt(i)
+    hash *= prime
+  }
+
+  return hash
+}
+
 export class OccurrenceCounter {
   constructor() {
     this._items = Object.create(null)
   }
 
   push(item) {
-    if (this._items[item]) {
-      return this._items[item]++
+    const key = hash(item)
+
+    if (this._items[key]) {
+      return this._items[key]++
     }
 
-    return this._items[item] = 1
+    return this._items[key] = 1
   }
 
   count() {


### PR DESCRIPTION
Savings are 10-70%. Stringified object sizes for OccurenceCounter on all fixture files:


| after | before | savings (%) |
|------|------|-----------|
| 34572 | 84178 | 58.9% |
| 108939 | 245099 | 55.6% |
| 21128 | 42686 | 50.5% |
| 46000 | 64120 | 28.3% |
| 101655 | 191168 | 46.8% |
| 169657 | 582293 | 70.9% |
| 31212 | 53986 | 42.2% |
| 36559 | 80900 | 54.8% |
| 52992 | 128524 | 58.8% |
| 76910 | 85849 | 10.4% |
| 70587 | 164539 | 57.1% |
| 48026 | 67838 | 29.2% |
| 27687 | 60559 | 54.3% |
| 33358 | 72049 | 53.7% |
| 23371 | 47306 | 50.6% |
| 37409 | 53253 | 29.8% |
| 97601 | 167161 | 41.6% |
| 165180 | 442160 | 62.6% |
| 55741 | 119955 | 53.5% |
| 76385 | 173473 | 56.0% |