### PR TITLE
Report selector combinators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projectwallace/css-analyzer",
-  "version": "5.10.1",
+  "version": "5.11.0-alpha.2",
   "author": "Bart Veneman",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projectwallace/css-analyzer",
-  "version": "5.11.0-alpha.2",
+  "version": "5.11.0-alpha.3",
   "author": "Bart Veneman",
   "repository": {
     "type": "git",

--- a/src/__fixtures__/bol-com-20190617.json
+++ b/src/__fixtures__/bol-com-20190617.json
@@ -57084,6 +57084,17 @@
       },
       "uniquenessRatio": 1,
       "ratio": 0.02534138655462185
+    },
+    "combinators": {
+      "total": 4849,
+      "totalUnique": 4,
+      "unique": {
+        " ": 4139,
+        ">": 588,
+        "+": 43,
+        "~": 79
+      },
+      "uniquenessRatio": 0.0008249123530624871
     }
   },
   "declarations": {

--- a/src/__fixtures__/bootstrap-5.0.0.json
+++ b/src/__fixtures__/bootstrap-5.0.0.json
@@ -24083,6 +24083,17 @@
       },
       "uniquenessRatio": 0.926829268292683,
       "ratio": 0.014648088603072526
+    },
+    "combinators": {
+      "total": 706,
+      "totalUnique": 4,
+      "unique": {
+        " ": 322,
+        ">": 249,
+        "+": 113,
+        "~": 22
+      },
+      "uniquenessRatio": 0.0056657223796034
     }
   },
   "declarations": {

--- a/src/__fixtures__/cnn-20220403.json
+++ b/src/__fixtures__/cnn-20220403.json
@@ -153182,6 +153182,17 @@
       },
       "uniquenessRatio": 0.7477477477477478,
       "ratio": 0.005654898364664527
+    },
+    "combinators": {
+      "total": 34225,
+      "totalUnique": 4,
+      "unique": {
+        " ": 32028,
+        "+": 491,
+        "~": 409,
+        ">": 1297
+      },
+      "uniquenessRatio": 0.0001168736303871439
     }
   },
   "declarations": {

--- a/src/__fixtures__/css-tricks-20190319.json
+++ b/src/__fixtures__/css-tricks-20190319.json
@@ -20584,6 +20584,17 @@
       },
       "uniquenessRatio": 1,
       "ratio": 0.012743926722421346
+    },
+    "combinators": {
+      "total": 2938,
+      "totalUnique": 4,
+      "unique": {
+        " ": 2604,
+        ">": 327,
+        "~": 5,
+        "+": 2
+      },
+      "uniquenessRatio": 0.0013614703880190605
     }
   },
   "declarations": {

--- a/src/__fixtures__/facebook-20190319.json
+++ b/src/__fixtures__/facebook-20190319.json
@@ -40263,6 +40263,17 @@
       },
       "uniquenessRatio": 1,
       "ratio": 0.0066725978647686835
+    },
+    "combinators": {
+      "total": 1150,
+      "totalUnique": 4,
+      "unique": {
+        " ": 1049,
+        ">": 89,
+        "+": 9,
+        "~": 3
+      },
+      "uniquenessRatio": 0.0034782608695652175
     }
   },
   "declarations": {

--- a/src/__fixtures__/gazelle-20210905.json
+++ b/src/__fixtures__/gazelle-20210905.json
@@ -94262,6 +94262,17 @@
       },
       "uniquenessRatio": 0.96,
       "ratio": 0.002123502930434044
+    },
+    "combinators": {
+      "total": 16258,
+      "totalUnique": 4,
+      "unique": {
+        " ": 13926,
+        ">": 1647,
+        "+": 643,
+        "~": 42
+      },
+      "uniquenessRatio": 0.00024603272235207283
     }
   },
   "declarations": {

--- a/src/__fixtures__/github-20210501.json
+++ b/src/__fixtures__/github-20210501.json
@@ -26139,6 +26139,17 @@
       },
       "uniquenessRatio": 0.95,
       "ratio": 0.013249420337860219
+    },
+    "combinators": {
+      "total": 843,
+      "totalUnique": 4,
+      "unique": {
+        " ": 733,
+        ">": 72,
+        "+": 34,
+        "~": 4
+      },
+      "uniquenessRatio": 0.004744958481613286
     }
   },
   "declarations": {

--- a/src/__fixtures__/indiatimes-20230219.json
+++ b/src/__fixtures__/indiatimes-20230219.json
@@ -54669,6 +54669,17 @@
       },
       "uniquenessRatio": 1,
       "ratio": 0.0006275100401606426
+    },
+    "combinators": {
+      "total": 10557,
+      "totalUnique": 4,
+      "unique": {
+        " ": 10509,
+        "~": 3,
+        ">": 41,
+        "+": 4
+      },
+      "uniquenessRatio": 0.0003788955195604812
     }
   },
   "declarations": {

--- a/src/__fixtures__/lego-20190617.json
+++ b/src/__fixtures__/lego-20190617.json
@@ -22495,6 +22495,17 @@
       },
       "uniquenessRatio": 1,
       "ratio": 0.014009844755774327
+    },
+    "combinators": {
+      "total": 2162,
+      "totalUnique": 4,
+      "unique": {
+        " ": 2052,
+        "~": 6,
+        ">": 75,
+        "+": 29
+      },
+      "uniquenessRatio": 0.0018501387604070306
     }
   },
   "declarations": {

--- a/src/__fixtures__/smashing-magazine-20190319.json
+++ b/src/__fixtures__/smashing-magazine-20190319.json
@@ -98346,6 +98346,17 @@
       },
       "uniquenessRatio": 0.42452830188679247,
       "ratio": 0.01815690304898938
+    },
+    "combinators": {
+      "total": 10464,
+      "totalUnique": 4,
+      "unique": {
+        " ": 10018,
+        ">": 251,
+        "+": 177,
+        "~": 18
+      },
+      "uniquenessRatio": 0.00038226299694189603
     }
   },
   "declarations": {

--- a/src/__fixtures__/trello-20190617.json
+++ b/src/__fixtures__/trello-20190617.json
@@ -40195,6 +40195,17 @@
       },
       "uniquenessRatio": 0.5,
       "ratio": 0.0057107893126657145
+    },
+    "combinators": {
+      "total": 1809,
+      "totalUnique": 4,
+      "unique": {
+        " ": 1413,
+        ">": 224,
+        "+": 10,
+        "~": 162
+      },
+      "uniquenessRatio": 0.002211166390270868
     }
   },
   "declarations": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -239,6 +239,12 @@ Api('handles empty input gracefully', () => {
         "uniquenessRatio": 0,
         "ratio": 0
       },
+      "combinators": {
+        "total": 0,
+        "totalUnique": 0,
+        "unique": {},
+        "uniquenessRatio": 0,
+      },
     },
     "declarations": {
       "total": 0,

--- a/src/selectors/selectors.test.js
+++ b/src/selectors/selectors.test.js
@@ -407,12 +407,15 @@ Selectors('counts combinators', () => {
 })
 
 Selectors('tracks combinator locations', () => {
-  let result = analyze(`
+  let css = `
     a b,
     a > b,
     a
-      b {}
-  `, {
+      b,
+    a:not(b) c,
+    a[attr] b {}
+  `
+  let result = analyze(css, {
     useUnstableLocations: true
   })
   let actual = result.selectors.combinators
@@ -430,6 +433,18 @@ Selectors('tracks combinator locations', () => {
         column: 6,
         offset: 26,
         length: 1,
+      },
+      {
+        line: 6,
+        column: 13,
+        offset: 48,
+        length: 1,
+      },
+      {
+        line: 7,
+        column: 12,
+        offset: 63,
+        length: 1,
       }
     ],
     '>': [
@@ -441,6 +456,15 @@ Selectors('tracks combinator locations', () => {
       }
     ]
   })
+
+  let as_strings = actual.__unstable__uniqueWithLocations[' ']
+    .map(loc => css.substring(loc.offset, loc.offset + loc.length))
+  assert.equal(as_strings, [
+    ' ',
+    `\n`,
+    ' ',
+    ' '
+  ])
 })
 
 Selectors('Can keep track of selector locations if we ask it to do so', () => {

--- a/src/selectors/selectors.test.js
+++ b/src/selectors/selectors.test.js
@@ -22,7 +22,7 @@ Selectors('are analyzed', () => {
   `
   const actual = analyze(fixture).selectors
 
-  // assert.equal(actual.total, 2)
+  assert.equal(actual.total, 2)
   assert.equal(actual.totalUnique, 2)
 })
 
@@ -91,6 +91,12 @@ Selectors('handles CSS without selectors', () => {
       unique: {},
       uniquenessRatio: 0,
       ratio: 0,
+    },
+    combinators: {
+      total: 0,
+      totalUnique: 0,
+      unique: {},
+      uniquenessRatio: 0,
     },
   }
   assert.equal(actual, expected)
@@ -331,6 +337,12 @@ Selectors('handles emoji selectors', () => {
       uniquenessRatio: 0,
       ratio: 0,
     },
+    combinators: {
+      total: 0,
+      totalUnique: 0,
+      unique: {},
+      uniquenessRatio: 0,
+    },
   }
   assert.equal(actual, expected)
 })
@@ -369,7 +381,69 @@ Selectors('analyzes vendor prefixed selectors', () => {
   })
 })
 
-Selectors('Can keep track of selector locations if we as it to do so', () => {
+Selectors('counts combinators', () => {
+  let result = analyze(`
+    a,
+    a b,
+    a > b,
+    a ~ b,
+    a + b,
+    a    b,
+    a + b c > d e ~ f,
+    :is(a + b, a, e > f) {
+    }
+  `)
+  let actual = result.selectors.combinators
+
+  assert.is(actual.total, 12)
+  assert.is(actual.totalUnique, 4)
+  assert.is(actual.uniquenessRatio, 4 / 12)
+  assert.equal(actual.unique, {
+    ' ': 4,
+    '>': 3,
+    '~': 2,
+    '+': 3
+  })
+})
+
+Selectors('tracks combinator locations', () => {
+  let result = analyze(`
+    a b,
+    a > b,
+    a
+      b {}
+  `, {
+    useUnstableLocations: true
+  })
+  let actual = result.selectors.combinators
+
+  assert.equal(actual.__unstable__uniqueWithLocations, {
+    ' ': [
+      {
+        line: 2,
+        column: 6,
+        offset: 6,
+        length: 1,
+      },
+      {
+        line: 4,
+        column: 6,
+        offset: 26,
+        length: 1,
+      }
+    ],
+    '>': [
+      {
+        line: 3,
+        column: 7,
+        offset: 16,
+        length: 1,
+      }
+    ]
+  })
+})
+
+Selectors('Can keep track of selector locations if we ask it to do so', () => {
   const fixture = `
     rule {
       color: green;

--- a/src/selectors/utils.js
+++ b/src/selectors/utils.js
@@ -119,7 +119,7 @@ export function getComplexity(selector) {
 }
 
 /**
- * Walk a selector node and trigger a callback every time  a Combinator was found
+ * Walk a selector node and trigger a callback every time a Combinator was found
  * We need create the `loc` for descendant combinators manually, because CSSTree
  * does not keep track of whitespace for us. We'll assume that the combinator is
  * alwas a single ` ` (space) character, even though there could be newlines or
@@ -128,15 +128,18 @@ export function getComplexity(selector) {
  * @param {*} onMatch
  */
 export function getCombinators(node, onMatch) {
-  let previousNode
-
-  walk(node, function (selectorNode) {
+  walk(node, function (
+    /** @type {import('css-tree').CssNode} */ selectorNode,
+    /** @type {import('css-tree').ListItem} */ item
+  ) {
     if (selectorNode.type === 'Combinator') {
+      // .loc is null when selectorNode.name === ' '
       if (selectorNode.loc === null) {
+        let previousLoc = item.prev.data.loc.end
         let start = {
-          offset: previousNode.offset,
-          line: previousNode.line,
-          column: previousNode.column
+          offset: previousLoc.offset,
+          line: previousLoc.line,
+          column: previousLoc.column
         }
 
         onMatch({
@@ -156,10 +159,6 @@ export function getCombinators(node, onMatch) {
           loc: selectorNode.loc
         })
       }
-    }
-
-    if (selectorNode.loc !== null) {
-      previousNode = selectorNode.loc.end
     }
   })
 }


### PR DESCRIPTION
closes #334 

I'm really worried for performance/memory usage in cases like CNN where we need to keep track of 30,000+ locations when `useUnstableLocations` is enabled.