### PR TITLE
store node locations for font-face rules

### DIFF
--- a/src/atrules/atrules.test.js
+++ b/src/atrules/atrules.test.js
@@ -199,6 +199,95 @@ AtRules('finds @font-face', () => {
   assert.equal(actual, expected)
 })
 
+AtRules('finds @font-face', () => {
+  const fixture = `
+    @font-face {
+      font-family: Arial;
+      src: url("https://url-to-arial.woff");
+    }
+
+    @font-face {
+      font-display: swap;
+      font-family: Test;
+      font-stretch: condensed;
+      font-style: italic;
+      font-weight: 700;
+      font-variant: no-common-ligatures proportional-nums;
+      font-feature-settings: "liga" 0;
+      font-variation-settings: "xhgt" 0.7;
+      src: local("Input Mono");
+      unicode-range: U+0025-00FF;
+    }
+
+    @font-face {
+      font-family: 'Input Mono';
+      src: local('Input Mono') url("https://url-to-input-mono.woff");
+    }
+
+    @font-face {
+      font-family: MyHelvetica;
+      src: local("Helvetica Neue Bold"), local("HelveticaNeue-Bold"), url(MgOpenModernaBold.ttf);
+      font-weight: bold;
+    }
+
+    /* Duplicate @font-face in Media Query */
+    @media (min-width: 1000px) {
+      @font-face {
+        font-family: 'Input Mono';
+        src: local('Input Mono') url("https://url-to-input-mono.woff");
+      }
+    }`
+  const actual = analyze(fixture, {
+    useUnstableLocations: true
+  }).atrules.fontface.__unstable_uniqueWithLocations
+  const expected = {
+    total: 5,
+    totalUnique: 5,
+    unique: {
+      5: 1,
+      100: 1,
+      463: 1,
+      590: 1,
+      850: 1,
+    },
+    __unstable__uniqueWithLocations: {
+      5: [{
+        line: 2,
+        column: 5,
+        offset: 5,
+        length: 89,
+      }],
+      100: [{
+        line: 7,
+        column: 5,
+        offset: 100,
+        length: 357,
+      }],
+      463: [{
+        line: 20,
+        column: 5,
+        offset: 463,
+        length: 121,
+      }],
+      590: [{
+        line: 25,
+        column: 5,
+        offset: 590,
+        length: 173,
+      }],
+      850: [{
+        line: 33,
+        column: 7,
+        offset: 850,
+        length: 127,
+      }],
+    },
+    uniquenessRatio: 1
+  }
+
+  assert.equal(actual, expected)
+})
+
 AtRules('handles @font-face encoding issues (GH-307)', () => {
   // Actual CSS once found in a <style> tag on vistaprint.nl
   // CSSTree parses it without errors, but analyzer failed on it;

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ export function analyze(css, options = {}) {
   let totalAtRules = 0
   /** @type {Record<string: string>}[]} */
   let fontfaces = []
+  let fontfaces_with_loc = new Collection(useLocations)
   let layers = new Collection(useLocations)
   let imports = new Collection(useLocations)
   let medias = new Collection(useLocations)
@@ -180,6 +181,10 @@ export function analyze(css, options = {}) {
 
         if (atRuleName === 'font-face') {
           let descriptors = {}
+
+          if (useLocations) {
+            fontfaces_with_loc.p(node.loc.start.offset, node.loc)
+          }
 
           node.block.children.forEach(descriptor => {
             // Ignore 'Raw' nodes in case of CSS syntax errors
@@ -642,12 +647,14 @@ export function analyze(css, options = {}) {
       }),
     },
     atrules: {
-      fontface: {
+      fontface: assign({
         total: fontFacesCount,
         totalUnique: fontFacesCount,
         unique: fontfaces,
-        uniquenessRatio: fontFacesCount === 0 ? 0 : 1
-      },
+        uniquenessRatio: fontFacesCount === 0 ? 0 : 1,
+      }, useLocations ? {
+        __unstable_uniqueWithLocations: fontfaces_with_loc.c(),
+      } : {}),
       import: imports.c(),
       media: assign(
         medias.c(),


### PR DESCRIPTION
It's a pretty whacky setup with the double `__unstable_uniqueWithLocations`, but it does the job. And it's `unstable` anyway.

closes #354 