### PR TITLE
fix: do not crash on `var(--x, )` in font shorthand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -528,12 +528,17 @@ export function analyze(css, options = {}) {
           else if (isProperty('font', property)) {
             if (isSystemFont(node)) return
 
-            let { font_size, line_height, font_family } = destructure(node, stringifyNode, function (item) {
+            let result = destructure(node, stringifyNode, function (item) {
               if (item.type === 'keyword') {
                 valueKeywords.p(item.value, loc)
               }
             })
 
+            if (!result) {
+              return this.skip
+            }
+
+            let { font_size, line_height, font_family } = result
             if (font_family) {
               fontFamilies.p(font_family, loc)
             }

--- a/src/values/destructure-font-shorthand.js
+++ b/src/values/destructure-font-shorthand.js
@@ -40,13 +40,18 @@ export function isSystemFont(node) {
  * @param {*} stringifyNode
  */
 export function destructure(value, stringifyNode, cb) {
-	let font_family = Array.from({ length: 2 })
+	/** @type {Array<import('css-tree').CssNode | undefined>} */
+	let font_family = [,]
 	/** @type {string | undefined} */
 	let font_size
 	/** @type {string | undefined} */
 	let line_height
 
-	// FIXME: in case of a var(--my-stack, fam1, fam2, fam3) this forEach also loops over all children of the var()
+	// Bail out if the value is a single var()
+	if (value.children.first.type === 'Function' && value.children.first.name.toLowerCase() === 'var') {
+		return null
+	}
+
 	value.children.forEach(function (node, item) {
 		let prev = item.prev ? item.prev.data : undefined
 		let next = item.next ? item.next.data : undefined

--- a/src/values/font-families.test.js
+++ b/src/values/font-families.test.js
@@ -109,6 +109,17 @@ FontFamilies('does not crash on 14px "Inter Var", sans-serif, 700', () => {
   })
 })
 
+FontFamilies('does not crash on var(--x, )', () => {
+  const fixture = `
+    a {
+      font: var(--x, );
+    }
+  `
+  assert.not.throws(() => {
+    analyze(fixture).values.fontFamilies
+  })
+})
+
 FontFamilies('handles system fonts', () => {
   // Source: https://drafts.csswg.org/css-fonts-3/#font-prop
   const fixture = `


### PR DESCRIPTION
closes #471 