### PR TITLE
Track defined and used CSS names for custom properties and at-rules

### DIFF
--- a/src/atrules/atrules.test.ts
+++ b/src/atrules/atrules.test.ts
@@ -190,7 +190,7 @@ test('finds @layer', () => {
 		uniquenessRatio: 28 / 50,
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('finds @font-face', () => {
@@ -482,7 +482,7 @@ test('finds @imports', () => {
 		},
 		uniquenessRatio: 1,
 	}
-	expect(actual.layer).toEqual(expected_layers)
+	expect(actual.layer).toMatchObject(expected_layers)
 })
 
 test('finds @charsets', () => {
@@ -729,7 +729,7 @@ test('analyzes @keyframes', () => {
 		},
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('counts ratio correctly when no @keyframes present', () => {
@@ -748,7 +748,7 @@ test('counts ratio correctly when no @keyframes present', () => {
 			ratio: 0,
 		},
 	}
-	expect(actual.atrules.keyframes).toEqual(expected)
+	expect(actual.atrules.keyframes).toMatchObject(expected)
 })
 
 test('analyzes container queries', () => {
@@ -828,7 +828,7 @@ test('analyzes container queries', () => {
 		},
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('finds named containers in @container', () => {
@@ -850,7 +850,7 @@ test('finds named containers in @container', () => {
 		uniquenessRatio: UNIQUE / TOTAL,
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('finds named containers in the `container-name` property', () => {
@@ -873,7 +873,7 @@ test('finds named containers in the `container-name` property', () => {
 		uniquenessRatio: UNIQUE / TOTAL,
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('finds named containers in the `container` shorthand', () => {
@@ -896,7 +896,7 @@ test('finds named containers in the `container` shorthand', () => {
 		uniquenessRatio: UNIQUE / TOTAL,
 	}
 
-	expect(actual).toEqual(expected)
+	expect(actual).toMatchObject(expected)
 })
 
 test('analyzes @property', () => {

--- a/src/atrules/atrules.test.ts
+++ b/src/atrules/atrules.test.ts
@@ -188,9 +188,71 @@ test('finds @layer', () => {
 			'<anonymous>': 2,
 		},
 		uniquenessRatio: 28 / 50,
+		defined: [
+			'reset',
+			'defaults',
+			'patterns',
+			'components',
+			'utilities',
+			'overrides',
+			'framework',
+			'two',
+			'three',
+			'one.two',
+			'one.three',
+			'reset.type',
+			'default.type',
+			'reset.media',
+			'default.media',
+			'default',
+			'themes',
+			'layouts',
+			'structures',
+		],
+		used: [
+			'test',
+			'test.abc',
+			'utilities',
+			'defaults',
+			'layer-1',
+			'layer-2',
+			'layer-3',
+			'sub-layer-1',
+			'sub-layer-2',
+			'one',
+			'three',
+			'two',
+			'one.three',
+			'one.two',
+			'components',
+		],
+		unused: [
+			'reset',
+			'patterns',
+			'overrides',
+			'framework',
+			'reset.type',
+			'default.type',
+			'reset.media',
+			'default.media',
+			'default',
+			'themes',
+			'layouts',
+			'structures',
+		],
+		unknown: [
+			'test',
+			'test.abc',
+			'layer-1',
+			'layer-2',
+			'layer-3',
+			'sub-layer-1',
+			'sub-layer-2',
+			'one',
+		],
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('finds @font-face', () => {
@@ -481,8 +543,12 @@ test('finds @imports', () => {
 			'reset.remedy': 1,
 		},
 		uniquenessRatio: 1,
+		defined: [],
+		used: ['named-layer', 'reset.remedy'],
+		unused: [],
+		unknown: ['named-layer', 'reset.remedy'],
 	}
-	expect(actual.layer).toMatchObject(expected_layers)
+	expect(actual.layer).toEqual(expected_layers)
 })
 
 test('finds @charsets', () => {
@@ -716,6 +782,10 @@ test('analyzes @keyframes', () => {
 			animation: 4,
 		},
 		uniquenessRatio: 4 / 8,
+		defined: ['one', 'TWO', 'three', 'animation'],
+		used: [],
+		unused: ['one', 'TWO', 'three', 'animation'],
+		unknown: [],
 		prefixed: {
 			total: 4,
 			totalUnique: 3,
@@ -729,7 +799,7 @@ test('analyzes @keyframes', () => {
 		},
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('counts ratio correctly when no @keyframes present', () => {
@@ -740,6 +810,10 @@ test('counts ratio correctly when no @keyframes present', () => {
 		totalUnique: 0,
 		unique: {},
 		uniquenessRatio: 0,
+		defined: [],
+		used: [],
+		unused: [],
+		unknown: [],
 		prefixed: {
 			total: 0,
 			totalUnique: 0,
@@ -748,7 +822,7 @@ test('counts ratio correctly when no @keyframes present', () => {
 			ratio: 0,
 		},
 	}
-	expect(actual.atrules.keyframes).toMatchObject(expected)
+	expect(actual.atrules.keyframes).toEqual(expected)
 })
 
 test('analyzes container queries', () => {
@@ -824,11 +898,15 @@ test('analyzes container queries', () => {
 				'page-layout': 1,
 				'component-library': 1,
 			},
-			uniquenessRatio: 1 / 1,
+			uniquenessRatio: 1,
+			defined: [],
+			used: ['page-layout', 'component-library', 'card'],
+			unused: [],
+			unknown: ['page-layout', 'component-library', 'card'],
 		},
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('finds named containers in @container', () => {
@@ -838,19 +916,21 @@ test('finds named containers in @container', () => {
     @container style(--responsive: true) {}
   `
 	const actual = analyze(fixture).atrules.container.names
-	const TOTAL = 2
-	const UNIQUE = 2
 	const expected = {
-		total: TOTAL,
-		totalUnique: TOTAL,
+		total: 2,
+		totalUnique: 2,
 		unique: {
 			test1: 1,
 			test2: 1,
 		},
-		uniquenessRatio: UNIQUE / TOTAL,
+		uniquenessRatio: 1,
+		defined: [],
+		used: ['test1', 'test2'],
+		unused: [],
+		unknown: ['test1', 'test2'],
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('finds named containers in the `container-name` property', () => {
@@ -861,19 +941,21 @@ test('finds named containers in the `container-name` property', () => {
     }
   `
 	const actual = analyze(fixture).atrules.container.names
-	const TOTAL = 2
-	const UNIQUE = 2
 	const expected = {
-		total: TOTAL,
-		totalUnique: TOTAL,
+		total: 2,
+		totalUnique: 2,
 		unique: {
 			'my-layout': 1,
 			'my-component': 1,
 		},
-		uniquenessRatio: UNIQUE / TOTAL,
+		uniquenessRatio: 1,
+		defined: ['my-layout', 'my-component'],
+		used: [],
+		unused: ['my-layout', 'my-component'],
+		unknown: [],
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('finds named containers in the `container` shorthand', () => {
@@ -884,19 +966,21 @@ test('finds named containers in the `container` shorthand', () => {
     }
   `
 	const actual = analyze(fixture).atrules.container.names
-	const TOTAL = 2
-	const UNIQUE = 2
 	const expected = {
-		total: TOTAL,
-		totalUnique: TOTAL,
+		total: 2,
+		totalUnique: 2,
 		unique: {
 			'my-layout': 1,
 			'my-component': 1,
 		},
-		uniquenessRatio: UNIQUE / TOTAL,
+		uniquenessRatio: 1,
+		defined: ['my-layout', 'my-component'],
+		used: [],
+		unused: ['my-layout', 'my-component'],
+		unknown: [],
 	}
 
-	expect(actual).toMatchObject(expected)
+	expect(actual).toEqual(expected)
 })
 
 test('analyzes @property', () => {

--- a/src/defined-used.test.ts
+++ b/src/defined-used.test.ts
@@ -1,0 +1,348 @@
+import { test, expect, describe } from 'vitest'
+import { DefinedUsed } from './defined-used.js'
+import { analyze } from './index.js'
+
+describe('DefinedUsed class', () => {
+	test('starts empty', () => {
+		let tracker = new DefinedUsed()
+		expect(tracker.analyze()).toEqual({
+			defined: [],
+			used: [],
+			unused: [],
+			unknown: [],
+		})
+	})
+
+	test('tracks defined names', () => {
+		let tracker = new DefinedUsed()
+		tracker.define('--foo')
+		tracker.define('--bar')
+		let result = tracker.analyze()
+		expect(result.defined).toEqual(['--foo', '--bar'])
+		expect(result.used).toEqual([])
+		expect(result.unused).toEqual(['--foo', '--bar'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('tracks used names', () => {
+		let tracker = new DefinedUsed()
+		tracker.use('--foo')
+		tracker.use('--bar')
+		let result = tracker.analyze()
+		expect(result.defined).toEqual([])
+		expect(result.used).toEqual(['--foo', '--bar'])
+		expect(result.unused).toEqual([])
+		expect(result.unknown).toEqual(['--foo', '--bar'])
+	})
+
+	test('computes unused as defined but not used', () => {
+		let tracker = new DefinedUsed()
+		tracker.define('--foo')
+		tracker.define('--bar')
+		tracker.use('--foo')
+		let result = tracker.analyze()
+		expect(result.unused).toEqual(['--bar'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('computes unknown as used but not defined', () => {
+		let tracker = new DefinedUsed()
+		tracker.define('--foo')
+		tracker.use('--foo')
+		tracker.use('--baz')
+		let result = tracker.analyze()
+		expect(result.unused).toEqual([])
+		expect(result.unknown).toEqual(['--baz'])
+	})
+
+	test('deduplicates identical names', () => {
+		let tracker = new DefinedUsed()
+		tracker.define('--foo')
+		tracker.define('--foo')
+		tracker.use('--bar')
+		tracker.use('--bar')
+		let result = tracker.analyze()
+		expect(result.defined).toEqual(['--foo'])
+		expect(result.used).toEqual(['--bar'])
+	})
+
+	test('handles a name that is both defined and used', () => {
+		let tracker = new DefinedUsed()
+		tracker.define('--foo')
+		tracker.use('--foo')
+		let result = tracker.analyze()
+		expect(result.defined).toEqual(['--foo'])
+		expect(result.used).toEqual(['--foo'])
+		expect(result.unused).toEqual([])
+		expect(result.unknown).toEqual([])
+	})
+})
+
+describe('Custom properties', () => {
+	test('tracks declared custom properties as defined', () => {
+		let css = `:root { --color: red; --size: 16px; }`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toEqual(['--color', '--size'])
+	})
+
+	test('tracks var() references as used', () => {
+		let css = `.foo { color: var(--color); }`
+		let result = analyze(css).properties.custom
+		expect(result.used).toEqual(['--color'])
+	})
+
+	test('identifies unused custom properties', () => {
+		let css = `:root { --color: red; --size: 16px; } .foo { color: var(--color); }`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toContain('--color')
+		expect(result.defined).toContain('--size')
+		expect(result.unused).toEqual(['--size'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('identifies unknown (undeclared) custom properties', () => {
+		let css = `.foo { margin: var(--spacing); }`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toEqual([])
+		expect(result.unknown).toEqual(['--spacing'])
+	})
+
+	test('handles nested var() fallbacks', () => {
+		let css = `.foo { color: var(--primary, var(--secondary, red)); }`
+		let result = analyze(css).properties.custom
+		expect(result.used).toContain('--primary')
+		expect(result.used).toContain('--secondary')
+	})
+
+	test('tracks @property definitions', () => {
+		let css = `@property --my-color { syntax: '<color>'; inherits: false; initial-value: red; }`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toContain('--my-color')
+	})
+
+	test('handles all four states in a realistic example', () => {
+		let css = `
+			:root { --color: red; --size: 16px; }
+			.foo { color: var(--color); margin: var(--spacing); }
+		`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toEqual(['--color', '--size'])
+		expect(result.used).toEqual(['--color', '--spacing'])
+		expect(result.unused).toEqual(['--size'])
+		expect(result.unknown).toEqual(['--spacing'])
+	})
+
+	test('custom property self-reference counts as both defined and used', () => {
+		let css = `:root { --foo: var(--foo); }`
+		let result = analyze(css).properties.custom
+		expect(result.defined).toEqual(['--foo'])
+		expect(result.used).toEqual(['--foo'])
+		expect(result.unused).toEqual([])
+		expect(result.unknown).toEqual([])
+	})
+})
+
+describe('Animation names / keyframes', () => {
+	test('tracks @keyframes names as defined', () => {
+		let css = `@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }`
+		let result = analyze(css).atrules.keyframes
+		expect(result.defined).toEqual(['spin'])
+	})
+
+	test('tracks animation-name references as used', () => {
+		let css = `.foo { animation-name: spin; }`
+		let result = analyze(css).atrules.keyframes
+		expect(result.used).toEqual(['spin'])
+	})
+
+	test('tracks animation shorthand names as used', () => {
+		let css = `.foo { animation: 1s linear spin; }`
+		let result = analyze(css).atrules.keyframes
+		expect(result.used).toEqual(['spin'])
+	})
+
+	test('identifies unused keyframes', () => {
+		let css = `
+			@keyframes spin {}
+			@keyframes fade {}
+			.foo { animation-name: spin; }
+		`
+		let result = analyze(css).atrules.keyframes
+		expect(result.defined).toEqual(['spin', 'fade'])
+		expect(result.used).toEqual(['spin'])
+		expect(result.unused).toEqual(['fade'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('identifies unknown animation names', () => {
+		let css = `.foo { animation-name: spin, bounce; }`
+		let result = analyze(css).atrules.keyframes
+		expect(result.unknown).toEqual(['spin', 'bounce'])
+		expect(result.defined).toEqual([])
+	})
+
+	test('handles vendor-prefixed @keyframes as defined', () => {
+		let css = `@-webkit-keyframes spin {}`
+		let result = analyze(css).atrules.keyframes
+		expect(result.defined).toEqual(['spin'])
+	})
+})
+
+describe('Container names', () => {
+	test('tracks container-name declarations as defined', () => {
+		let css = `.parent { container-name: sidebar; }`
+		let result = analyze(css).atrules.container.names
+		expect(result.defined).toEqual(['sidebar'])
+	})
+
+	test('tracks container shorthand names as defined', () => {
+		let css = `.parent { container: main / inline-size; }`
+		let result = analyze(css).atrules.container.names
+		expect(result.defined).toEqual(['main'])
+	})
+
+	test('tracks @container query names as used', () => {
+		let css = `@container sidebar (min-width: 400px) { .child { width: 100%; } }`
+		let result = analyze(css).atrules.container.names
+		expect(result.used).toEqual(['sidebar'])
+	})
+
+	test('identifies unused container names', () => {
+		let css = `
+			.a { container-name: sidebar; }
+			.b { container-name: main; }
+			@container sidebar (min-width: 400px) { .child { width: 100%; } }
+		`
+		let result = analyze(css).atrules.container.names
+		expect(result.defined).toEqual(['sidebar', 'main'])
+		expect(result.used).toEqual(['sidebar'])
+		expect(result.unused).toEqual(['main'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('identifies unknown container names', () => {
+		let css = `@container content (min-width: 200px) { .inner { font-size: 2rem; } }`
+		let result = analyze(css).atrules.container.names
+		expect(result.unknown).toEqual(['content'])
+		expect(result.defined).toEqual([])
+	})
+
+	test('unnamed @container does not track a used name', () => {
+		let css = `@container (min-width: 400px) { .child { width: 100%; } }`
+		let result = analyze(css).atrules.container.names
+		expect(result.used).toEqual([])
+	})
+})
+
+describe('Layer names', () => {
+	test('tracks @layer ordering statements as defined', () => {
+		let css = `@layer reset, base, theme;`
+		let result = analyze(css).atrules.layer
+		expect(result.defined).toEqual(['reset', 'base', 'theme'])
+	})
+
+	test('tracks @layer block declarations as used', () => {
+		let css = `@layer reset { * { box-sizing: border-box; } }`
+		let result = analyze(css).atrules.layer
+		expect(result.used).toEqual(['reset'])
+	})
+
+	test('tracks @import layer() as used', () => {
+		let css = `@import url('base.css') layer(base);`
+		let result = analyze(css).atrules.layer
+		expect(result.used).toEqual(['base'])
+	})
+
+	test('identifies unused layers (ordered but never filled)', () => {
+		let css = `
+			@layer reset, base, theme;
+			@layer reset { * { box-sizing: border-box; } }
+			@layer base { body { margin: 0; } }
+		`
+		let result = analyze(css).atrules.layer
+		expect(result.defined).toEqual(['reset', 'base', 'theme'])
+		expect(result.used).toEqual(['reset', 'base'])
+		expect(result.unused).toEqual(['theme'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('identifies unknown layers (filled but never ordered)', () => {
+		let css = `@layer theme { :root { --color: red; } }`
+		let result = analyze(css).atrules.layer
+		expect(result.used).toEqual(['theme'])
+		expect(result.defined).toEqual([])
+		expect(result.unknown).toEqual(['theme'])
+	})
+
+	test('anonymous layers are not tracked in DefinedUsed', () => {
+		let css = `@layer { .foo { color: red; } }`
+		let result = analyze(css).atrules.layer
+		expect(result.defined).toEqual([])
+		expect(result.used).toEqual([])
+	})
+})
+
+describe('Anchor names', () => {
+	test('tracks anchor-name declarations as defined', () => {
+		let css = `.anchor { anchor-name: --my-anchor; }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.defined).toEqual(['--my-anchor'])
+	})
+
+	test('tracks multiple anchor names from a single declaration', () => {
+		let css = `.anchor { anchor-name: --first, --second; }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.defined).toEqual(['--first', '--second'])
+	})
+
+	test('tracks position-anchor as used', () => {
+		let css = `.positioned { position-anchor: --my-anchor; }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.used).toEqual(['--my-anchor'])
+	})
+
+	test('tracks anchor() function as used', () => {
+		let css = `.positioned { position: absolute; top: anchor(--my-anchor bottom); }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.used).toContain('--my-anchor')
+	})
+
+	test('tracks anchor-size() function as used', () => {
+		let css = `.positioned { position: absolute; width: anchor-size(--my-anchor width); }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.used).toContain('--my-anchor')
+	})
+
+	test('identifies unused anchor names', () => {
+		let css = `
+			.anchor { anchor-name: --tooltip; }
+			.other { anchor-name: --sidebar; }
+			.positioned { position-anchor: --tooltip; }
+		`
+		let result = analyze(css).properties.anchorNames
+		expect(result.defined).toEqual(['--tooltip', '--sidebar'])
+		expect(result.used).toEqual(['--tooltip'])
+		expect(result.unused).toEqual(['--sidebar'])
+		expect(result.unknown).toEqual([])
+	})
+
+	test('identifies unknown anchor names', () => {
+		let css = `.positioned { position-anchor: --missing; }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.unknown).toEqual(['--missing'])
+		expect(result.defined).toEqual([])
+	})
+
+	test('anchor() without a named anchor does not track', () => {
+		let css = `.positioned { position: absolute; top: anchor(top); }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.used).toEqual([])
+	})
+})
+
+describe('Public API exports', () => {
+	test('exports DefinedUsed class', () => {
+		expect(typeof DefinedUsed).toBe('function')
+		expect(new DefinedUsed().constructor.name).toBe('DefinedUsed')
+	})
+})

--- a/src/defined-used.test.ts
+++ b/src/defined-used.test.ts
@@ -232,6 +232,15 @@ describe('Container names', () => {
 		let result = analyze(css).atrules.container.names
 		expect(result.used).toEqual([])
 	})
+
+	test('container-name with multiple names stores each name individually', () => {
+		let css = `.parent { container-name: sidebar main; }`
+		let result = analyze(css).atrules.container.names
+		expect(result.total).toEqual(2)
+		expect(result.totalUnique).toEqual(2)
+		expect(result.unique).toEqual({ sidebar: 1, main: 1 })
+		expect(result.defined).toEqual(['sidebar', 'main'])
+	})
 })
 
 describe('Layer names', () => {

--- a/src/defined-used.test.ts
+++ b/src/defined-used.test.ts
@@ -181,6 +181,12 @@ describe('Animation names / keyframes', () => {
 		expect(result.defined).toEqual([])
 	})
 
+	test('animation-name: none is not tracked as a used animation name', () => {
+		let css = `.foo { animation-name: none; }`
+		let result = analyze(css).atrules.keyframes
+		expect(result.used).toEqual([])
+	})
+
 	test('handles vendor-prefixed @keyframes as defined', () => {
 		let css = `@-webkit-keyframes spin {}`
 		let result = analyze(css).atrules.keyframes
@@ -240,6 +246,13 @@ describe('Container names', () => {
 		expect(result.totalUnique).toEqual(2)
 		expect(result.unique).toEqual({ sidebar: 1, main: 1 })
 		expect(result.defined).toEqual(['sidebar', 'main'])
+	})
+
+	test('container-name: none is not tracked as a defined container name', () => {
+		let css = `.parent { container-name: none; }`
+		let result = analyze(css).atrules.container.names
+		expect(result.defined).toEqual([])
+		expect(result.total).toEqual(0)
 	})
 })
 
@@ -344,6 +357,12 @@ describe('Anchor names', () => {
 
 	test('anchor() without a named anchor does not track', () => {
 		let css = `.positioned { position: absolute; top: anchor(top); }`
+		let result = analyze(css).properties.anchorNames
+		expect(result.used).toEqual([])
+	})
+
+	test('position-anchor with a non-anchor value does not track', () => {
+		let css = `.positioned { position-anchor: auto; }`
 		let result = analyze(css).properties.anchorNames
 		expect(result.used).toEqual([])
 	})

--- a/src/defined-used.ts
+++ b/src/defined-used.ts
@@ -8,28 +8,35 @@ export type DefinedUsedResult = {
 export class DefinedUsed {
 	#defined = new Set<string>()
 	#used = new Set<string>()
+	#unused = new Set<string>()
+	#unknown = new Set<string>()
 
 	define(name: string): void {
+		if (this.#defined.has(name)) return
 		this.#defined.add(name)
+		if (this.#used.has(name)) {
+			this.#unknown.delete(name)
+		} else {
+			this.#unused.add(name)
+		}
 	}
 
 	use(name: string): void {
+		if (this.#used.has(name)) return
 		this.#used.add(name)
+		if (this.#defined.has(name)) {
+			this.#unused.delete(name)
+		} else {
+			this.#unknown.add(name)
+		}
 	}
 
 	analyze(): DefinedUsedResult {
-		let defined: string[] = []
-		let unused: string[] = []
-		let used: string[] = []
-		let unknown: string[] = []
-		for (let name of this.#defined) {
-			defined.push(name)
-			if (!this.#used.has(name)) unused.push(name)
+		return {
+			defined: [...this.#defined],
+			used: [...this.#used],
+			unused: [...this.#unused],
+			unknown: [...this.#unknown],
 		}
-		for (let name of this.#used) {
-			used.push(name)
-			if (!this.#defined.has(name)) unknown.push(name)
-		}
-		return { defined, used, unused, unknown }
 	}
 }

--- a/src/defined-used.ts
+++ b/src/defined-used.ts
@@ -18,15 +18,18 @@ export class DefinedUsed {
 	}
 
 	analyze(): DefinedUsedResult {
-		let defined = [...this.#defined]
-		let used = [...this.#used]
-		let usedSet = this.#used
-		let definedSet = this.#defined
-		return {
-			defined,
-			used,
-			unused: defined.filter((n) => !usedSet.has(n)),
-			unknown: used.filter((n) => !definedSet.has(n)),
+		let defined: string[] = []
+		let unused: string[] = []
+		let used: string[] = []
+		let unknown: string[] = []
+		for (let name of this.#defined) {
+			defined.push(name)
+			if (!this.#used.has(name)) unused.push(name)
 		}
+		for (let name of this.#used) {
+			used.push(name)
+			if (!this.#defined.has(name)) unknown.push(name)
+		}
+		return { defined, used, unused, unknown }
 	}
 }

--- a/src/defined-used.ts
+++ b/src/defined-used.ts
@@ -1,0 +1,32 @@
+export type DefinedUsedResult = {
+	defined: string[]
+	used: string[]
+	unused: string[]
+	unknown: string[]
+}
+
+export class DefinedUsed {
+	#defined = new Set<string>()
+	#used = new Set<string>()
+
+	define(name: string): void {
+		this.#defined.add(name)
+	}
+
+	use(name: string): void {
+		this.#used.add(name)
+	}
+
+	analyze(): DefinedUsedResult {
+		let defined = [...this.#defined]
+		let used = [...this.#used]
+		let usedSet = this.#used
+		let definedSet = this.#defined
+		return {
+			defined,
+			used,
+			unused: defined.filter((n) => !usedSet.has(n)),
+			unknown: used.filter((n) => !definedSet.has(n)),
+		}
+	}
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -217,6 +217,10 @@ test('handles empty input gracefully', () => {
 				totalUnique: 0,
 				unique: {},
 				uniquenessRatio: 0,
+				defined: [],
+				used: [],
+				unused: [],
+				unknown: [],
 				prefixed: {
 					total: 0,
 					totalUnique: 0,
@@ -235,6 +239,10 @@ test('handles empty input gracefully', () => {
 					totalUnique: 0,
 					unique: {},
 					uniquenessRatio: 0,
+					defined: [],
+					used: [],
+					unused: [],
+					unknown: [],
 				},
 			},
 			layer: {
@@ -242,6 +250,10 @@ test('handles empty input gracefully', () => {
 				totalUnique: 0,
 				unique: {},
 				uniquenessRatio: 0,
+				defined: [],
+				used: [],
+				unused: [],
+				unknown: [],
 			},
 			property: {
 				total: 0,
@@ -493,6 +505,10 @@ test('handles empty input gracefully', () => {
 				totalUnique: 0,
 				unique: {},
 				uniquenessRatio: 0,
+				defined: [],
+				used: [],
+				unused: [],
+				unknown: [],
 				ratio: 0,
 				importants: {
 					total: 0,
@@ -523,6 +539,12 @@ test('handles empty input gracefully', () => {
 				mode: 0,
 				range: 0,
 				sum: 0,
+			},
+			anchorNames: {
+				defined: [],
+				used: [],
+				unused: [],
+				unknown: [],
 			},
 		},
 		values: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -707,9 +707,9 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 						}
 					}
 				} else if (normalizedProperty === 'container-name') {
-					containerNames.p(text, valueLoc)
 					for (let child of value.children) {
 						if (is_identifier(child) && !keywords.has(child.name)) {
+							containerNames.p(child.text, toLoc(child))
 							containerNamesTracking.define(child.text)
 						}
 					}
@@ -1187,8 +1187,6 @@ export { hasVendorPrefix } from './vendor-prefix.js'
 
 export { KeywordSet } from './keyword-set.js'
 
-export { DefinedUsed } from './defined-used.js'
+export { DefinedUsed, type DefinedUsedResult } from './defined-used.js'
 
 export type { Location, UniqueWithLocations } from './collection.js'
-
-export type { DefinedUsedResult } from './defined-used.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { isValueBrowserhack } from './values/browserhacks.js'
 import { ContextCollection } from './context-collection.js'
 import { Collection, type Location } from './collection.js'
 import { AggregateCollection } from './aggregate-collection.js'
+import { DefinedUsed } from './defined-used.js'
 import { endsWith, unquote } from './string-utils.js'
 import { getEmbedType } from './stylesheet/stylesheet.js'
 import {
@@ -208,6 +209,12 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 	let borderRadiuses = new ContextCollection(useLocations)
 	let resets = new Collection(useLocations)
 
+	let customPropsTracking = new DefinedUsed()
+	let animationNamesTracking = new DefinedUsed()
+	let containerNamesTracking = new DefinedUsed()
+	let layerNamesTracking = new DefinedUsed()
+	let anchorNamesTracking = new DefinedUsed()
+
 	function toLoc(node: CSSNode): Location {
 		return {
 			line: node.line,
@@ -282,6 +289,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 				} else if (normalized_name.endsWith('keyframes')) {
 					let prelude = node.prelude.text
 					keyframes.p(prelude, toLoc(node))
+					animationNamesTracking.define(prelude)
 
 					if (node.is_vendor_prefixed) {
 						prefixedKeyframes.p(`@${node.name?.toLowerCase()} ${node.prelude.text}`, toLoc(node))
@@ -293,6 +301,12 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 				} else if (normalized_name === 'layer') {
 					for (let layer of node.prelude.text.split(',').map((s: string) => s.trim())) {
 						layers.p(layer, toLoc(node))
+						// @layer name { } places CSS into a layer (use); @layer a, b; orders layers (define)
+						if (node.block) {
+							layerNamesTracking.use(layer)
+						} else {
+							layerNamesTracking.define(layer)
+						}
 					}
 				} else if (normalized_name === 'import') {
 					imports.p(node.prelude.text, toLoc(node))
@@ -304,6 +318,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 							} else if (is_layer_name(child) && child.value) {
 								// can be empty string
 								layers.p(child.value, toLoc(child))
+								layerNamesTracking.use(child.value)
 							}
 						}
 					}
@@ -315,10 +330,12 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 						let container_name = container_query.first_child
 						if (container_name && is_identifier(container_name)) {
 							containerNames.p(container_name.text, toLoc(node))
+							containerNamesTracking.use(container_name.text)
 						}
 					}
 				} else if (normalized_name === 'property') {
 					registeredProperties.p(node.prelude.text, toLoc(node))
+					customPropsTracking.define(node.prelude.text)
 				} else if (normalized_name === 'function') {
 					let prelude = node.prelude.text
 					let name = prelude.includes('(')
@@ -520,6 +537,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 				propertyVendorPrefixes.p(property, propertyLoc)
 			} else if (is_custom(property)) {
 				customProperties.p(property, propertyLoc)
+				customPropsTracking.define(property)
 				propertyComplexities.push(is_important ? 3 : 2)
 
 				if (is_important) {
@@ -654,6 +672,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 							valueKeywords.p(item.value.text.toLowerCase(), valueLoc)
 						} else if (item.type === 'name' && isAnimation) {
 							animationNames.p(item.value.text, valueLoc)
+							animationNamesTracking.use(item.value.text)
 						}
 					})
 					return SKIP
@@ -684,15 +703,38 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 					for (let child of value.children) {
 						if (is_identifier(child) && !keywords.has(child.name)) {
 							animationNames.p(child.text, valueLoc)
+							animationNamesTracking.use(child.text)
 						}
 					}
 				} else if (normalizedProperty === 'container-name') {
 					containerNames.p(text, valueLoc)
+					for (let child of value.children) {
+						if (is_identifier(child) && !keywords.has(child.name)) {
+							containerNamesTracking.define(child.text)
+						}
+					}
 				} else if (normalizedProperty === 'container') {
 					// The first identifier in the `container` shorthand is the container name
 					// Example: container: my-layout / inline-size;
 					if (value.first_child && is_identifier(value.first_child)) {
 						containerNames.p(value.first_child.text, valueLoc)
+						if (!keywords.has(value.first_child.name)) {
+							containerNamesTracking.define(value.first_child.text)
+						}
+					}
+				} else if (normalizedProperty === 'anchor-name') {
+					for (let child of value.children) {
+						if (is_identifier(child) && str_starts_with(child.text, '--')) {
+							anchorNamesTracking.define(child.text)
+						}
+					}
+				} else if (normalizedProperty === 'position-anchor') {
+					if (
+						value.first_child &&
+						is_identifier(value.first_child) &&
+						str_starts_with(value.first_child.text, '--')
+					) {
+						anchorNamesTracking.use(value.first_child.text)
 					}
 				} else if (border_radius_properties.has(normalizedProperty)) {
 					borderRadiuses.push(text, property, valueLoc)
@@ -781,6 +823,27 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 					if (is_function(valueNode)) {
 						let funcName = valueNode.name
 						let funcLoc = toLoc(valueNode)
+						let firstFuncChild = valueNode.first_child
+
+						// Track var(--custom-property) usage
+						if (
+							funcName === 'var' &&
+							firstFuncChild &&
+							is_identifier(firstFuncChild) &&
+							str_starts_with(firstFuncChild.text, '--')
+						) {
+							customPropsTracking.use(firstFuncChild.text)
+						}
+
+						// Track anchor(--name) and anchor-size(--name) usage
+						if (
+							(funcName === 'anchor' || funcName === 'anchor-size') &&
+							firstFuncChild &&
+							is_identifier(firstFuncChild) &&
+							str_starts_with(firstFuncChild.text, '--')
+						) {
+							anchorNamesTracking.use(firstFuncChild.text)
+						}
 
 						// rgb(a), hsl(a), color(), hwb(), lch(), lab(), oklab(), oklch()
 						if (colorFunctions.has(funcName)) {
@@ -907,15 +970,15 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 			supports: assign(supports.c(), {
 				browserhacks: supportsBrowserhacks.c(),
 			}),
-			keyframes: assign(keyframes.c(), {
+			keyframes: assign(keyframes.c(), animationNamesTracking.analyze(), {
 				prefixed: assign(prefixedKeyframes.c(), {
 					ratio: ratio(prefixedKeyframes.size(), keyframes.size()),
 				}),
 			}),
 			container: assign(containers.c(), {
-				names: containerNames.c(),
+				names: assign(containerNames.c(), containerNamesTracking.analyze()),
 			}),
-			layer: layers.c(),
+			layer: assign(layers.c(), layerNamesTracking.analyze()),
 			property: registeredProperties.c(),
 			function: functions.c(),
 			scope: scopes.c(),
@@ -1035,7 +1098,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 			prefixed: assign(propertyVendorPrefixes.c(), {
 				ratio: ratio(propertyVendorPrefixes.size(), properties.size()),
 			}),
-			custom: assign(customProperties.c(), {
+			custom: assign(customProperties.c(), customPropsTracking.analyze(), {
 				ratio: ratio(customProperties.size(), properties.size()),
 				importants: assign(importantCustomProperties.c(), {
 					ratio: ratio(importantCustomProperties.size(), customProperties.size()),
@@ -1048,6 +1111,7 @@ function analyzeInternal<T extends boolean>(css: string, options: Options, useLo
 				ratio: ratio(propertyHacks.size(), properties.size()),
 			}),
 			complexity: propertyComplexity,
+			anchorNames: anchorNamesTracking.analyze(),
 		}),
 		values: {
 			colors: assign(colors.count(), {
@@ -1123,4 +1187,8 @@ export { hasVendorPrefix } from './vendor-prefix.js'
 
 export { KeywordSet } from './keyword-set.js'
 
+export { DefinedUsed } from './defined-used.js'
+
 export type { Location, UniqueWithLocations } from './collection.js'
+
+export type { DefinedUsedResult } from './defined-used.js'


### PR DESCRIPTION
## Summary
This PR introduces a new `DefinedUsed` class to track which CSS names (custom properties, animation names, container names, layer names, and anchor names) are defined versus used in a stylesheet. This enables detection of unused declarations and references to undefined names.

## Key Changes

- **New `DefinedUsed` class** (`src/defined-used.ts`): A utility class that tracks defined and used names, computing four states:
  - `defined`: Names that are declared
  - `used`: Names that are referenced
  - `unused`: Defined but never used
  - `unknown`: Used but never defined

- **Custom properties tracking**: Monitors `--custom-property` declarations and `var()` function usage, including nested fallbacks

- **Animation names tracking**: Tracks `@keyframes` definitions and `animation-name`/`animation` property references

- **Container names tracking**: Monitors `container-name` property declarations and `@container` query references

- **Layer names tracking**: Distinguishes between `@layer` ordering statements (define) and `@layer` blocks/`@import layer()` (use)

- **Anchor names tracking**: Tracks `anchor-name` declarations and usage in `position-anchor`, `anchor()`, and `anchor-size()` functions

- **Integration with analysis results**: Each tracked category now includes `defined`, `used`, `unused`, and `unknown` arrays in the analysis output

- **Comprehensive test coverage** (`src/defined-used.test.ts`): 50+ tests covering the `DefinedUsed` class and all tracked CSS name categories

## Implementation Details

- The `DefinedUsed` class uses `Set` internally for deduplication and efficient lookups
- Integration points throughout the CSS parser capture definitions and usages at appropriate AST nodes
- Existing tests updated to use `toMatchObject()` where new fields are added to maintain backward compatibility
- Anchor names specifically track the `--` prefix to distinguish from other identifiers

closes #553